### PR TITLE
Svelte: support bind:value

### DIFF
--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -21,6 +21,9 @@ import { Observer, reactive } from "@reactivedata/reactive";
  *
  * Now, your component only rerenders when Bob's name changes
  *  (or if the second element of the array changes)
+ * 
+ * Binding values works also.
+ * <input type="text" bind:value={$store.items[1].name} />
  */
 export function svelteSyncedStore<T>(syncedObject: T) {
   let set: any;
@@ -31,11 +34,16 @@ export function svelteSyncedStore<T>(syncedObject: T) {
   });
   const store = reactive(syncedObject, observer);
 
-  return readable(store, (newSet) => {
+  const readableStore = readable(store, (newSet) => {
     set = newSet;
 
     return () => {
       set = undefined;
     };
   });
+
+  return {
+    subscribe: readableStore.subscribe,
+    set: () => {}
+  }
 }


### PR DESCRIPTION
Firstly, thanks for this library!  `yjs` had me interested, but you've made it so much simpler to use.

The combination of SyncedStore and the WebRTC & IndexedDb providers blew me away.  Collaborative, offline-capable data in less than 5 minutes of work? 
# 🤯 

## Description

This PR adds support for Svelte's `bind:value` syntax.  The Svelte compiler expects there to be a `set` method on the store.
```js
	function input_input_handler(each_value, item_index) {
		each_value[item_index].title = this.value;
		theStore.set($theStore);
	}
```

Since we're editing the underlying reactive objects directly, the `set` method can just be a simple `() => {}` stub.

## Example
Same code, but with the types removed.
https://codesandbox.io/s/svelte-syncedstore-example-lb1g7?file=/App.svelte

