### PR TITLE
Docs: Svelte integration

### DIFF
--- a/docs/docs/svelte.md
+++ b/docs/docs/svelte.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 4
+sidebar_label: Svelte
+---
+
+# Svelte integration
+
+_SyncedStore_ works seamlessly together with [Svelte Stores](https://svelte.dev/docs#run-time-svelte-store).
+
+```javascript
+import { syncedStore, getYjsValue } from "@syncedstore/core";
+import { svelteSyncedStore } from "@syncedstore/svelte";
+
+// Create your SyncedStore store
+const todoStore = syncedStore({ todos: [] });
+
+// Create Svelte Store for use in your components.
+// You can treat this like any other store, including `bind`.
+export const store = svelteSyncedStore(todoStore);
+```
+
+See this example of creating a collaborative Todo application with Svelte and SyncedStore:
+
+```javascript svelte
+<script>
+	import { store } from "./store.js";
+
+	let newTodo = "";
+
+	const addTodo = () => {
+	  const value = newTodo && newTodo.trim();
+
+	  if (!value) {
+	    return;
+	  }
+	  $store.todos.push({
+	    title: value,
+	    completed: false
+	  });
+	  newTodo = "";
+	};
+
+	const removeTodo = todo => {
+	  $store.todos.splice($store.todos.indexOf(todo), 1);
+	};
+</script>
+
+<main id="app">
+	<h1>Todo Svelte</h1>
+	<form on:submit|preventDefault={addTodo}>
+		<input
+				class="new-todo"
+				autocomplete="off"
+				placeholder="What needs to be done?"
+				bind:value={newTodo}
+			/>
+		</form>
+	<ul class="todo-list">
+		{#each $store.todos as todo}
+				<li class="todo">
+					<div>
+						<label>
+							<input class="toggle" type="checkbox" bind:checked={todo.completed} />
+							{ todo.title }
+						</label>
+						<button class="destroy" on:click={() => removeTodo(todo)}>Delete</button>
+					</div>
+				</li>
+			{/each}
+		</ul>
+</main>
+```


### PR DESCRIPTION
Here's a basic Svelte docs page with static code blocks.

As mentioned in the previous PR, I've had issues with Sandpack and Svelte.

I was able to set up a Svelte REPL that mostly works.  For some reason it stops rendering the list of TODOs if you remove the `<pre>` block that is subscribed to the entire store.   What's neat is that you can collaborate on the TODOs using the React and Vue examples from your other docs pages.

https://svelte.dev/repl/a3eb6fab2c8a47019ca7dc12701f6b7b?version=3.46.3

I updated my previous Codesanbox example to use the updated `@syncedstore/svelte` npm package.  Work great, even if you remove the `<pre>` block.  
https://codesandbox.io/s/reverent-glitter-lb1g7?file=/App.svelte

Example (and buggy online playgrounds) aside, I hope to integrate this library into a Svelte app I've been building.

I may try to write up a tutorial as I learn more.
