### PR TITLE
Add support for array.every

### DIFF
--- a/packages/core/src/array.ts
+++ b/packages/core/src/array.ts
@@ -66,6 +66,10 @@ function arrayImplementation<T>(arr: Y.Array<T>) {
       return [].forEach.apply(slice.apply(this), arguments);
     } as T[]["forEach"],
 
+    every: function () {
+      return [].every.apply(slice.apply(this), arguments);
+    },
+
     filter: function () {
       return [].filter.apply(slice.apply(this), arguments);
     } as T[]["filter"],
@@ -142,9 +146,8 @@ export function crdtArray<T>(initializer: T[], arr = new Y.Array<T>()) {
       if (typeof p !== "number") {
         throw new Error();
       }
-      throw new Error("array assignment is not implemented / supported");
       // TODO map.set(p, smartValue(value));
-      return true;
+      throw new Error("array assignment is not implemented / supported");
     },
     get: (target, pArg, receiver) => {
       const p = propertyToNumber(pArg);

--- a/packages/core/test/crdt.test.ts
+++ b/packages/core/test/crdt.test.ts
@@ -195,6 +195,15 @@ describe("SyncedStore", () => {
     expect(store1.arr).toEqual([0, 1]);
   });
 
+  it("every() for array", () => {
+    let store1 = syncedStore({ map: {} as any }).map;
+    store1.arr = [0, 1, 2, 3];
+    const areAllNumbersSmallerThan10 = store1.arr.every((n) => n < 10);
+    expect(areAllNumbersSmallerThan10).toEqual(true);
+    const areAllNumbersSmallersThan2 = store1.arr.every((n) => n < 2);
+    expect(areAllNumbersSmallersThan2).toEqual(false);
+  });
+
   it("move already inserted object to different location in document (nested)", () => {
     let store1 = syncedStore({ map: {} as any }).map;
     store1.mymap = {};


### PR DESCRIPTION
There are a few basic array methods missing in the current array proxy implementation, `every` is one of them so this is a small PR to add it. 

I would like to add `set` by index next. I see you are throwing an error there. What do you think about implementing it using splice?


