### PR TITLE
Feat/solid bindings

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from "yjs";
 import { crdtDoc, DocTypeDescription } from "./doc";
 
-export { enableMobxBindings, enableVueBindings } from "@syncedstore/yjs-reactive-bindings";
+export { enableMobxBindings, enableVueBindings, enableSolidBindings } from "@syncedstore/yjs-reactive-bindings";
 export { Box, boxed } from "./boxed";
 export * from "./util";
 /**

--- a/packages/yjs-reactive-bindings/src/index.ts
+++ b/packages/yjs-reactive-bindings/src/index.ts
@@ -105,4 +105,9 @@ export function makeYDocObservable(doc: Y.Doc) {
   });
 }
 
-export { enableMobxBindings, enableReactiveBindings, enableVueBindings } from "./observableProvider";
+export {
+  enableMobxBindings,
+  enableReactiveBindings,
+  enableVueBindings,
+  enableSolidBindings,
+} from "./observableProvider";

--- a/packages/yjs-reactive-bindings/src/observableProvider.ts
+++ b/packages/yjs-reactive-bindings/src/observableProvider.ts
@@ -73,6 +73,31 @@ export function enableVueBindings(vue: any) {
   customReaction = undefined;
 }
 
+/**
+ * Enable Solid integration
+ *
+ * @param solid An instance of Solid, e.g. import * as solid from "solid/store";
+ */
+export function enableSolidBindings(solid: any) {
+  customCreateAtom = function (name: any, onBecomeObserved: any) {
+    let id = 0;
+    const data = solid.createMutable({ data: id });
+    const atom = {
+      reportObserved() {
+        return data.data as any as boolean;
+      },
+      reportChanged() {
+        data.data = ++id;
+      },
+    };
+    if (onBecomeObserved) {
+      onBecomeObserved();
+    }
+    return atom;
+  };
+  customReaction = undefined;
+}
+
 export function enableReactiveBindings(reactive: any) {
   customCreateAtom = function (name, onBecomeObserved, onBecomeUnobserved) {
     // TMP


### PR DESCRIPTION
this PR adds solid-bindings to SyncedStore.
The PR is quite minimal: Solid's [createMutable](https://www.solidjs.com/docs#createmutable) proofed to be an excellent candidate for wiring SyncedStore's reactivity with Solid. 

Besides that I introduced an extra proxy-trap in the array-getter.

Instead of mapping (react like react), solid has [control flow-components ](https://www.solidjs.com/docs/latest#control-flow) to deal with arrays (and objects with solid-primitive's [Entries](https://github.com/solidjs-community/solid-primitives/tree/main/packages/keyed#readme)):

a react's`store.todos.map(todo => todo.title)` would be idiomatically written in solid like `<For each={store.todos}>{todo => todo.title}</For>`. `<For each={store.todos}>` was currently not working, as store.todos returned a reference to the Yjs-object (I assume) instead of the array of proxies. A spread was needed `<For each={[...store.todos]}>` which I believe would be cause of confusion and bugs when being used in a solid codebase.

An extra proxy-trap (not sure about the terminology) is introduced to allow an idiomatic use of arrays and objects in Solid's control flow components: in the Proxy-getter of array we check if the array is being accessed with a symbol that isn't one of SyncedStore's `if (typeof p === "symbol" && p !== $reactiveproxy && p !== $reactive && p !== $skipreactive)`. If this is the case we return a map of the YjsReturnValues.

I am unsure if this proxy-trap has any implications for other frameworks.

