### PR TITLE
add types to export definitions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
   "module": "dist/syncedstore.module.js",
   "umd:main": "dist/syncedstore.umd.js",
   "exports": {
+    "types": "./types/index.d.ts",
     "require": "./dist/syncedstore.js",
     "default": "./dist/syncedstore.modern.mjs"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,7 @@
   "module": "dist/syncedstore-react.module.js",
   "umd:main": "dist/syncedstore-react.umd.js",
   "exports": {
+    "types": "./types/index.d.ts",
     "require": "./dist/syncedstore-react.js",
     "default": "./dist/syncedstore-react.modern.mjs"
   },

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -22,6 +22,7 @@
   "module": "dist/syncedstore-svelte.module.js",
   "umd:main": "dist/syncedstore-svelte.umd.js",
   "exports": {
+    "types": "./types/index.d.ts",
     "require": "./dist/syncedstore-svelte.js",
     "default": "./dist/syncedstore-svelte.modern.mjs"
   },

--- a/packages/yjs-reactive-bindings/package.json
+++ b/packages/yjs-reactive-bindings/package.json
@@ -7,6 +7,7 @@
   "module": "dist/yjs-reactive-bindings.module.js",
   "umd:main": "dist/yjs-reactive-bindings.umd.js",
   "exports": {
+    "types": "./types/index.d.ts",
     "require": "./dist/yjs-reactive-bindings.js",
     "default": "./dist/yjs-reactive-bindings.modern.mjs"
   },


### PR DESCRIPTION
Exports type declarations for compatibility with [typescript module resolution strategies](https://www.typescriptlang.org/tsconfig#moduleResolution) `node16`/`nodenext` and `bundler`.

Resolves the problem:
```
Could not find a declaration file for module '@syncedstore/core'. '/node_modules/@syncedstore/core/dist/syncedstore.modern.mjs' implicitly has an 'any' type.
  There are types at /node_modules/@syncedstore/core/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@syncedstore/core' library may need to update its package.json or typings.ts(7016)
```

Should resolve #107 , as the [recomended TypeScript (5.x) compiler options for bun.sh](https://bun.sh/docs/runtime/typescript#recommended-compileroptions) appears to be `bundler`.