### PR TITLE
FIX: update @reactivedata/reactive dependency version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
   "types": "types/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@reactivedata/reactive": "0.2.0",
+    "@reactivedata/reactive": "^0.2.0",
     "@syncedstore/yjs-reactive-bindings": "^0.5.2",
     "@types/eslint": "6.8.0"
   },


### PR DESCRIPTION
Update the @reactivedata/reactive dependency to "^0.2.0" to fix reactive dependency version mismatch caused by @reactivedata/react.

This is to resolve https://github.com/YousefED/SyncedStore/issues/114