### PR TITLE
allow overwriting array methods even on frozen objects

### DIFF
--- a/packages/core/src/array.ts
+++ b/packages/core/src/array.ts
@@ -132,7 +132,11 @@ function arrayImplementation<T>(arr: Y.Array<T>) {
 
   const ret = [];
   for (let method in methods) {
-    ret[method] = methods[method];
+    Object.defineProperty(ret, method, {
+      value: methods[method],
+      writable: true,
+      configurable: true
+    })
   }
 
   // this is necessary to prevent errors like "trap reported non-configurability for property 'length' which is either non-existent or configurable in the proxy target" when adding support for ownKeys and Reflect.keysx


### PR DESCRIPTION
I'm opening this because I'm starting to use "ses" (secure ecmascript) and that freezes the array prototype, so that things like "slice" are set to readonly properties.

This change allows the functionality here to continue to work, even on frozen objects.