### PR TITLE
npmignore tsconfig.json

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,1 +1,2 @@
 test
+tsconfig.json


### PR DESCRIPTION
Sorry about the silly pull request. `tsconfig.json` is currently [included](https://www.npmjs.com/package/@syncedstore/core?activeTab=code) in the released package. It points to `../../tsconfig.json`, which means `node_modules/tsconfig.json`, which doesn't exist. Who cares? Apparently VS Code cares, and shows this as (currently) the only warning in my project.
<img width="662" alt="image" src="https://github.com/user-attachments/assets/647c213b-e3cf-4973-bf89-c50b3f588924">

Thanks a lot for SyncedStore and Reactive! I'm just getting into CRDT and I'm a big fan so far!